### PR TITLE
Basic self-prediction U-Net model

### DIFF
--- a/src/organoids.py
+++ b/src/organoids.py
@@ -22,7 +22,6 @@ class Organoids(Dataset):
         self.transform_task2 = spd.get_distortion_transform(task2)
         self.basic_transform = transforms.Compose([
             transforms.ConvertImageDtype(torch.float32),
-            transforms.Normalize(mean=[0.5], std=[0.5]),
         ])
 
     def __len__(self):

--- a/src/selfprediction_model.py
+++ b/src/selfprediction_model.py
@@ -1,0 +1,53 @@
+# Source: Lab ML - https://nn.labml.ai/unet/index.html
+# https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/master/labml_nn/unet/__init__.py
+
+import torch
+# import torchvision.transforms.functional
+from torch import nn
+
+import src.unet_blocks as ub
+
+
+class UNet(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+
+        self.down_conv = nn.ModuleList([ub.DoubleConvolution(i, o) for i, o in
+                                        [(in_channels, 64), (64, 128), (128, 256), (256, 512)]])
+        self.down_sample = nn.ModuleList([ub.DownSample() for _ in range(4)])
+
+        self.middle_conv = ub.DoubleConvolution(512, 1024)
+
+        self.up_sample = nn.ModuleList([ub.UpSample(i, o) for i, o in
+                                        [(1024, 512), (512, 256), (256, 128), (128, 64)]])
+        self.up_conv = nn.ModuleList([ub.DoubleConvolution(i, o) for i, o in
+                                      [(1024, 512), (512, 256), (256, 128), (128, 64)]])
+
+        self.concat = nn.ModuleList([ub.CropAndConcat() for _ in range(4)])
+
+        self.final_conv = nn.Conv2d(64, out_channels, kernel_size=1)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor):
+        pass_through = []
+
+        for i in range(len(self.down_conv)):
+            x = self.down_conv[i](x)
+
+            pass_through.append(x)
+
+            x = self.down_sample[i](x)
+
+        x = self.middle_conv(x)
+
+        for i in range(len(self.up_conv)):
+            x = self.up_sample[i](x)
+
+            x = self.concat[i](x, pass_through.pop())
+
+            x = self.up_conv[i](x)
+
+        x = self.final_conv(x)
+        x = self.sigmoid(x)
+
+        return x

--- a/src/unet_blocks.py
+++ b/src/unet_blocks.py
@@ -1,0 +1,53 @@
+# Source: Lab ML - https://nn.labml.ai/unet/index.html
+# https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/master/labml_nn/unet/__init__.py
+
+import torch
+import torchvision.transforms.functional
+from torch import nn
+
+
+class DoubleConvolution(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+
+        self.first = nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1)
+        self.act1 = nn.ReLU()
+
+        self.second = nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1)
+        self.act2 = nn.ReLU()
+
+    def forward(self, x: torch.Tensor):
+        x = self.first(x)
+        x = self.act1(x)
+        x = self.second(x)
+        x = self.act2(x)
+        return x
+
+
+class DownSample(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.pool = nn.MaxPool2d(2)
+
+    def forward(self, x: torch.Tensor):
+        return self.pool(x)
+
+
+class UpSample(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+
+        self.up = nn.ConvTranspose2d(in_channels, out_channels, kernel_size=2, stride=2)
+
+    def forward(self, x: torch.Tensor):
+        return self.up(x)
+
+
+class CropAndConcat(nn.Module):
+    def forward(self, x: torch.Tensor, contracting_x: torch.Tensor):
+        contracting_x = torchvision.transforms.functional.center_crop(contracting_x, [x.shape[2], x.shape[3]])
+
+        x = torch.cat([x, contracting_x], dim=1)
+
+        return x

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -10,7 +10,7 @@ def test_organoids_dataset_downstream_train():
     assert len(dataset) == 40636
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_organoids_dataset_pretext_train():
@@ -20,7 +20,7 @@ def test_organoids_dataset_pretext_train():
     assert len(dataset) == 40631
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_organoids_dataset_test():
@@ -30,4 +30,4 @@ def test_organoids_dataset_test():
     assert len(dataset) == 20322
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0

--- a/tests/unit_distortion.py
+++ b/tests/unit_distortion.py
@@ -9,7 +9,7 @@ def test_selfprediction_distortion_blur():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_drop():
@@ -18,7 +18,7 @@ def test_selfprediction_distortion_drop():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_shuffle():
@@ -27,7 +27,7 @@ def test_selfprediction_distortion_shuffle():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_rotate():
@@ -36,7 +36,7 @@ def test_selfprediction_distortion_rotate():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_blur_boxes():
@@ -45,7 +45,7 @@ def test_selfprediction_distortion_blur_boxes():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_drop_pixel():
@@ -54,7 +54,7 @@ def test_selfprediction_distortion_drop_pixel():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_shuffle_rotate():
@@ -63,7 +63,7 @@ def test_selfprediction_distortion_shuffle_rotate():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_rotate_boxes():
@@ -72,7 +72,7 @@ def test_selfprediction_distortion_rotate_boxes():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_combination():
@@ -81,7 +81,7 @@ def test_selfprediction_distortion_combination():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_combination2():
@@ -90,7 +90,7 @@ def test_selfprediction_distortion_combination2():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_combination3():
@@ -99,7 +99,7 @@ def test_selfprediction_distortion_combination3():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_combination4():
@@ -108,7 +108,7 @@ def test_selfprediction_distortion_combination4():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0
 
 
 def test_selfprediction_distortion_no_task():
@@ -117,4 +117,4 @@ def test_selfprediction_distortion_no_task():
 
     assert sample.shape == (1, 320, 320)
     assert torch.max(sample) <= 1.0
-    assert torch.min(sample) >= -1.0
+    assert torch.min(sample) >= 0.0


### PR DESCRIPTION
Made image preprocessing normalize to [0 1]. Created basic U-Net building blocks and basic self-prediction U-Net implementation. With sigmoid activation at the end to ensure compatibility with input/gt data range. Closes #10 .